### PR TITLE
Feat react query

### DIFF
--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -16,7 +16,7 @@ jobs:
         with:
           fetch-depth: 0\
       - name: Install dependencies
-        run: yarn
+        run: npm ci
       - name: Publish to Chromatic
         if: github.ref != 'refs/heads/main'
         uses: chromaui/action@v1

--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -1,29 +1,30 @@
 # .github/workflows/chromatic.yml
-
-# Workflow name
 name: 'Chromatic'
 
-# Event for the workflow
-on: push
+on:
+  push:
+    branches-ignore:
+      - "develop"
 
 # List of jobs
 jobs:
   chromatic-deployment:
-    # Operating System
     runs-on: ubuntu-latest
-    # Job steps
     steps:
-      - uses: actions/checkout@v2
+      - name: Checkout repository
+        uses: actions/checkout@v2
         with:
-          fetch-depth: 0 # Required to retrieve git history
-
+          fetch-depth: 0\
       - name: Install dependencies
         run: yarn
-        # 👇 Adds Chromatic as a step in the workflow
-
       - name: Publish to Chromatic
+        if: github.ref != 'refs/heads/main'
         uses: chromaui/action@v1
-        # Chromatic GitHub Action options
         with:
-          # 👇 Chromatic projectToken, refer to the manage page to obtain it.
           projectToken: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}
+      - name: Publish to Chromatic and auto accept changes
+        if: github.ref == 'refs/heads/main'
+        uses: chromaui/action@v1
+        with:
+          projectToken: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}
+          autoAcceptChanges: true\

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -1,14 +1,28 @@
 import { BrowserRouter } from 'react-router-dom';
-import { ThemeProvider } from './libs/ThemeProvider';
+import { QueryClientProvider, QueryClient } from '@libs/query';
+import { ThemeProvider } from '@libs/ThemeProvider';
 import { AppRouter } from './routes/routes';
+
+const queryClient = new QueryClient({
+  defaultOptions: {
+    queries: {
+      refetchOnMount: false,
+      refetchOnReconnect: false,
+      refetchOnWindowFocus: false,
+      retry: 3,
+    },
+  },
+});
 
 function App() {
   return (
-    <BrowserRouter>
-      <ThemeProvider>
-        <AppRouter />
-      </ThemeProvider>
-    </BrowserRouter>
+    <QueryClientProvider client={queryClient}>
+      <BrowserRouter>
+        <ThemeProvider>
+          <AppRouter />
+        </ThemeProvider>
+      </BrowserRouter>
+    </QueryClientProvider>
   );
 }
 

--- a/src/app/components/Button/Button.stories.tsx
+++ b/src/app/components/Button/Button.stories.tsx
@@ -7,7 +7,7 @@ type ArgTypes = ComponentProps<typeof Button>;
 export default {
   title: 'components/Button',
   component: Button,
-  args: { children: 'Lorem Ipsum' },
+  args: { children: 'Lorem Ipsum is' },
   argTypes: {},
 } as Meta<ArgTypes>;
 

--- a/src/app/libs/query/index.ts
+++ b/src/app/libs/query/index.ts
@@ -1,0 +1,68 @@
+import { useMemo } from 'react';
+import {
+  useMutation as reactUseMutation,
+  useQuery as reactUseQuery,
+  useQueryClient,
+  QueryClient,
+  QueryClientProvider,
+} from 'react-query';
+
+export { QueryClient, QueryClientProvider, useQueryClient };
+
+export const queryKeyMap = new Map<
+  (...args: any[]) => Promise<any>,
+  [string]
+>();
+
+/**
+ * Apollo 와 동일한 signature 로 React Query 를 사용하기 위한 wrapper
+ */
+export const useQuery = <Variables, Result>(
+  queryFn: (...variables: Variables[]) => Promise<Result>,
+  options?: {
+    variables?: Variables;
+    skip?: boolean;
+    staleTime?: number;
+    cacheTime?: number;
+    onSuccess?: (result: Result) => void;
+    onError?: (err: Error) => void;
+    onSettled?: () => void;
+  }
+) => {
+  const { variables, skip, ...otherOPtions } = options || {};
+  const queryKey = useMemo(() => {
+    const queryKey = queryKeyMap.get(queryFn);
+    if (!queryKey) {
+      throw Error(`${queryFn.name} didn't set in queryKeyMap`);
+    }
+    return queryKey;
+  }, [queryFn]);
+
+  return reactUseQuery(
+    [...queryKey, ...Object.values(variables ?? {})],
+    () => (variables ? queryFn(variables) : queryFn()),
+    {
+      enabled: skip,
+      ...otherOPtions,
+    }
+  );
+};
+
+export const useMutation = <Variables, Result>(
+  mutateFn: (variables: Variables) => Promise<Result>
+) => {
+  const queryClient = useQueryClient();
+  const queryKey = useMemo(() => {
+    const queryKey = queryKeyMap.get(mutateFn);
+    if (!queryKey) {
+      throw Error(`${mutateFn.name} didn't set in queryKeyMap`);
+    }
+    return queryKey;
+  }, [mutateFn]);
+
+  return reactUseMutation(queryKey, mutateFn, {
+    onSuccess: () => {
+      queryClient.refetchQueries(queryKey, { exact: false });
+    },
+  });
+};

--- a/src/app/libs/query/index.ts
+++ b/src/app/libs/query/index.ts
@@ -49,7 +49,10 @@ export const useQuery = <Variables, Result>(
 };
 
 export const useMutation = <Variables, Result>(
-  mutateFn: (variables: Variables) => Promise<Result>
+  mutateFn: (variables: Variables) => Promise<Result>,
+  options?: {
+    disableRefetch?: boolean;
+  }
 ) => {
   const queryClient = useQueryClient();
   const queryKey = useMemo(() => {
@@ -62,7 +65,8 @@ export const useMutation = <Variables, Result>(
 
   return reactUseMutation(queryKey, mutateFn, {
     onSuccess: () => {
-      queryClient.refetchQueries(queryKey, { exact: false });
+      !options?.disableRefetch &&
+        queryClient.refetchQueries(queryKey, { exact: false });
     },
   });
 };


### PR DESCRIPTION
## chromatic 때문에 삽질 좀 하다가 다시 올립니다...

## 변경사항
* react-query를 wrapping 해서 씁니다.
* 회사에서 사용중인 것과 비슷하게 가져오면서 조금 간략화 했습니다.
* optimistic updates는 조금 더 고민해보겠습니다. 우선 refetch 하도록 했습니다.

## 사용방법
```typescript
const getSomething = fetchGetSomething;
const updateSomething =  fetchUpdateSomething;

queryKeyMap.set(getSomething, ['someKey']);
queryKeyMap.set(updateSomething, ['someKey']);

function SomeComponent() {
  const { data } = useQuery(getSomething, { variables: someVariables );
  const { mutateAsync } = useMutation(updateSomething)

  const handleClick = () => {
    mutateAsync();
  }

  return <button onClick={mutateAsync}>mutate</div>
}
```
대충 이런 식으로 queryKeyMap에 쿼리키를 셋해주면
mutation이 완료된 후 동일한 쿼리키를 가진 useQuery 들을 모두 refetch합니다.
문서로는 나중에 정리해두겠습니다...