### PR TITLE
SW-70 oauth api endpoint 변경

### DIFF
--- a/src/app/libs/auth/index.tsx
+++ b/src/app/libs/auth/index.tsx
@@ -102,16 +102,16 @@ export const useOauth = (): [
    */
   (
     code: string,
-    provider: 'google' | 'kakao' | 'github'
+    provider: OauthProvider
   ) => Promise<{ email: string; nickname: string; profileImage: string } | undefined>
 ] => {
   const { setUser } = useContext(AuthContext);
 
   const handleOauth = useCallback(
-    async (code: string, provider: 'google' | 'kakao' | 'github') => {
+    async (code: string, provider: OauthProvider) => {
       const result = await httpClient.post<
         { accessToken: string } | { email: string; nickname: string; profileImage: string }
-      >(`/auth/oauth/${provider}`, { code });
+      >(`/auth/${provider}`, { code });
 
       if ('accessToken' in result) {
         loadToken(result.accessToken);

--- a/src/app/models/user.ts
+++ b/src/app/models/user.ts
@@ -3,7 +3,7 @@ export type User = {
   email: string;
   nickname: string;
   profileImage: string;
-  provider: 'kakao' | 'github' | 'google' | 'link-gather';
+  provider: Provider;
   introduction: string;
   stacks: string[];
   career: any; // TODO:

--- a/src/app/screens/oauth/OauthCallbackScreen.tsx
+++ b/src/app/screens/oauth/OauthCallbackScreen.tsx
@@ -23,7 +23,7 @@ function OauthCallbackScreen() {
       return;
     }
 
-    handleOauth(code, provider as 'google' | 'kakao' | 'github').then((result) => {
+    handleOauth(code, provider as OauthProvider).then((result) => {
       if (result) {
         navigate('/sign-up', { state: result });
       } else {

--- a/src/app/types.ts
+++ b/src/app/types.ts
@@ -1,0 +1,3 @@
+type Provider = 'kakao' | 'github' | 'google' | 'link-gather';
+
+type OauthProvider = Exclude<Provider, 'link-gather'>;


### PR DESCRIPTION
### 개발내용
- oauth 와 auth(그냥 login) 의 로직이 거의 비슷해서 uri 똑같이 해도 될 것 같아 변경합니다.
  - 기존 : `POST /auth/oauth/:provider`
  - 변경 : `POST /auth/:provider`
- `types.ts`의 Provider만 수정해도 될 수 있도록 수정했습니다.

### 이슈링크
[oauth uri 변경](https://linkgather.atlassian.net/browse/SW-70)