### PR TITLE
chore: no-nested-ternary

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -26,5 +26,6 @@ module.exports = {
         endOfLine: 'auto',
       },
     ],
+    'no-nested-ternary': 'error',
   },
 };


### PR DESCRIPTION
중첩삼항연산자 금지로 변경했습니다.