### PR TITLE
[WIP] - 회원가입 API 연결 중

### DIFF
--- a/src/app/libs/query/index.ts
+++ b/src/app/libs/query/index.ts
@@ -50,6 +50,7 @@ export const useMutation = <Variables, Result>(
   options?: {
     disableRefetch?: boolean;
     onError?: (error: unknown) => void;
+    onSuccess?: (data: Result) => void;
   }
 ) => {
   const queryClient = useQueryClient();
@@ -62,8 +63,9 @@ export const useMutation = <Variables, Result>(
   }, [mutateFn]);
 
   return reactUseMutation(queryKey, mutateFn, {
-    onSuccess: () => {
+    onSuccess: (data: Result) => {
       !options?.disableRefetch && queryClient.refetchQueries(queryKey, { exact: false });
+      options?.onSuccess?.(data);
     },
     onError: options?.onError ?? ((error) => console.log(error)),
     // 에러가 떴는데 에러핸들링을 안했을 경우 콘솔로 찍히게끔.

--- a/src/app/libs/query/index.ts
+++ b/src/app/libs/query/index.ts
@@ -49,6 +49,7 @@ export const useMutation = <Variables, Result>(
   mutateFn: (variables: Variables) => Promise<Result>,
   options?: {
     disableRefetch?: boolean;
+    onError?: (error: unknown) => void;
   }
 ) => {
   const queryClient = useQueryClient();
@@ -64,5 +65,7 @@ export const useMutation = <Variables, Result>(
     onSuccess: () => {
       !options?.disableRefetch && queryClient.refetchQueries(queryKey, { exact: false });
     },
+    onError: options?.onError ?? ((error) => console.log(error)),
+    // 에러가 떴는데 에러핸들링을 안했을 경우 콘솔로 찍히게끔.
   });
 };

--- a/src/app/repositories/authRepository.ts
+++ b/src/app/repositories/authRepository.ts
@@ -1,0 +1,21 @@
+import { httpClient } from '@libs/http-client';
+import { queryKeyMap } from '@libs/query';
+
+export const authRepository = {
+  async emailVerification({ email, type }: { email: string; type: 'signup' | 'password' }) {
+    return httpClient.post('/auth/email-verification', { email, type });
+  },
+  async checkedVerificationId({ id }: { id: string }) {
+    return httpClient.get(`/auth/email-verification/${id}`);
+  },
+  async checkedVerificationCode({ code, id }: { code: string; id: string }) {
+    return httpClient.post(`/auth/email-verification/${id}`, { code });
+  },
+  async passwordChange({ id, password, passwordConfirm }: { id: string; password: string; passwordConfirm: string }) {
+    return httpClient.patch(`/auth/password-change/${id}`, { password, passwordConfirm });
+  },
+};
+
+queryKeyMap.set(authRepository.emailVerification, ['AuthEmailVerification']);
+queryKeyMap.set(authRepository.checkedVerificationCode, ['AuthCodeVerification']);
+queryKeyMap.set(authRepository.passwordChange, ['AuthChangePassword']);

--- a/src/app/repositories/authRepository.ts
+++ b/src/app/repositories/authRepository.ts
@@ -5,11 +5,11 @@ export const authRepository = {
   async emailVerification({ email, type }: { email: string; type: 'signup' | 'password' }) {
     return httpClient.post('/auth/email-verification', { email, type });
   },
+  async codeVerification({ code, id }: { code: string; id: string }) {
+    return httpClient.post(`/auth/email-verification/${id}`, { code });
+  },
   async checkedVerificationId({ id }: { id: string }) {
     return httpClient.get(`/auth/email-verification/${id}`);
-  },
-  async checkedVerificationCode({ code, id }: { code: string; id: string }) {
-    return httpClient.post(`/auth/email-verification/${id}`, { code });
   },
   async passwordChange({ id, password, passwordConfirm }: { id: string; password: string; passwordConfirm: string }) {
     return httpClient.patch(`/auth/password-change/${id}`, { password, passwordConfirm });
@@ -17,5 +17,5 @@ export const authRepository = {
 };
 
 queryKeyMap.set(authRepository.emailVerification, ['AuthEmailVerification']);
-queryKeyMap.set(authRepository.checkedVerificationCode, ['AuthCodeVerification']);
+queryKeyMap.set(authRepository.codeVerification, ['AuthCodeVerification']);
 queryKeyMap.set(authRepository.passwordChange, ['AuthChangePassword']);

--- a/src/app/repositories/index.ts
+++ b/src/app/repositories/index.ts
@@ -1,1 +1,2 @@
+export * from './authRepository';
 export * from './userRepository';

--- a/src/app/repositories/userRepository.ts
+++ b/src/app/repositories/userRepository.ts
@@ -5,10 +5,25 @@ export const userRepository = {
   async signIn({ email, password }: { email: string; password: string }) {
     return httpClient.post('/users/sign-in', { email, password });
   },
+  async signUp(params: {
+    email: string;
+    password: string;
+    nickname: string;
+    provider: string;
+    career: number;
+    job: string;
+    introduction: string;
+    stacks: string[];
+    urls: string[];
+    profileImage: string;
+  }) {
+    return httpClient.post('/users/sign-up', params);
+  },
   async checkNickname(nickname: string) {
     return httpClient.get(`/users/nickname-check?nickname=${nickname}`);
   },
 };
 
 queryKeyMap.set(userRepository.signIn, ['User']);
+queryKeyMap.set(userRepository.signUp, ['UserSignUp']);
 queryKeyMap.set(userRepository.checkNickname, ['UserNicknameCheck']);

--- a/src/app/repositories/userRepository.ts
+++ b/src/app/repositories/userRepository.ts
@@ -5,6 +5,10 @@ export const userRepository = {
   async signIn({ email, password }: { email: string; password: string }) {
     return httpClient.post('/users/sign-in', { email, password });
   },
+  async checkNickname(nickname: string) {
+    return httpClient.get(`/users/nickname-check?nickname=${nickname}`);
+  },
 };
 
 queryKeyMap.set(userRepository.signIn, ['User']);
+queryKeyMap.set(userRepository.checkNickname, ['UserNicknameCheck']);

--- a/src/app/screens/sign-up/SignUpScreen.tsx
+++ b/src/app/screens/sign-up/SignUpScreen.tsx
@@ -280,7 +280,7 @@ function SignUpScreen() {
 
   // query hooks
   const { mutateAsync: verifyEmailMutation } = useMutation(authRepository.emailVerification);
-  // const { mutateAsync: verifyCodeMutation } = useMutation(authRepository.checkedVerificationCode);
+  const { mutateAsync: verifyCodeMutation } = useMutation(authRepository.checkedVerificationCode);
 
   // const { data, isLoading, isError, error, refetch } = useQuery(userRepository.checkNickname, {
   //   variables: 'windy',
@@ -394,7 +394,9 @@ function SignUpScreen() {
                     <Input type='text' placeholder='코드입력' css={{ width: '288px' }} {...register('code')} />
                     <RequestButton
                       disabled={!watch('code')}
-                      // onClick={handleSubmit(async ({ code }) => await verifyCodeMutation({ code }))}
+                      onClick={async () =>
+                        await verifyCodeMutation({ code: getValues('code'), id: getValues('email') })
+                      }
                     >
                       확인
                     </RequestButton>

--- a/src/app/screens/sign-up/SignUpScreen.tsx
+++ b/src/app/screens/sign-up/SignUpScreen.tsx
@@ -11,6 +11,8 @@ import { yupResolver } from '@hookform/resolvers/yup';
 import { DropDown, SkillDropdown } from '@components';
 import { UnderlineTitle, Input, ShadowBox, TextArea, SkillTab, Button } from '@elements';
 import { SCHEMA_PASSWORD, SCHEMA_NICKNAME, SCHEMA_CONFIRM_PASSWORD } from '@libs/schema';
+import { userRepository, authRepository } from '@repositories';
+import { useMutation, useQuery } from '@libs/query';
 import styled from '@emotion/styled';
 import DeleteUrl from '@assets/images/icons/delete-url.svg';
 import IconSearch from '@assets/images/icons/icon-search.svg';
@@ -234,6 +236,7 @@ function SignUpScreen() {
     watch,
     control,
     getValues,
+    handleSubmit,
     formState: { errors, isValid, dirtyFields },
     setValue,
   } = useForm<ValidationType>({
@@ -274,7 +277,22 @@ function SignUpScreen() {
     remove: stacksRemove,
   } = useFieldArray({ control, name: 'stacks' });
   const { fields: urlsFields, append: urlsAppend, remove: urlsRemove } = useFieldArray({ control, name: 'urls' });
+
   // query hooks
+  const { mutateAsync: verifyEmailMutation } = useMutation(authRepository.emailVerification);
+  // const { mutateAsync: verifyCodeMutation } = useMutation(authRepository.checkedVerificationCode);
+
+  // const { data, isLoading, isError, error, refetch } = useQuery(userRepository.checkNickname, {
+  //   variables: 'windy',
+  //   skip: false,
+  //   onSuccess: (result) => {
+  //     console.log(result);
+  //   },
+  //   onError: (err) => {
+  //     console.log(err);
+  //   },
+  // });
+
   // calculated values
   // effects
   // handlers
@@ -365,11 +383,21 @@ function SignUpScreen() {
                 <Stack direction='column' spacing={4} css={{ marginTop: '25px' }}>
                   <Stack direction='row'>
                     <Input type='email' placeholder='이메일' css={{ width: '288px' }} {...register('email')} />
-                    <RequestButton disabled={!watch('email')}>인증요청</RequestButton>
+                    <RequestButton
+                      disabled={!watch('email')}
+                      onClick={async () => await verifyEmailMutation({ email: getValues('email'), type: 'signup' })}
+                    >
+                      인증요청
+                    </RequestButton>
                   </Stack>
                   <Stack direction='row'>
                     <Input type='text' placeholder='코드입력' css={{ width: '288px' }} {...register('code')} />
-                    <RequestButton disabled={!watch('code')}>확인</RequestButton>
+                    <RequestButton
+                      disabled={!watch('code')}
+                      // onClick={handleSubmit(async ({ code }) => await verifyCodeMutation({ code }))}
+                    >
+                      확인
+                    </RequestButton>
                   </Stack>
                   <Stack direction='row'>
                     <Input
@@ -499,7 +527,11 @@ function SignUpScreen() {
                     placeholder='닉네임 입력'
                     {...register('nickname')}
                   />
-                  <RequestButton disabled={!isValid} css={{ width: '93px' }}>
+                  <RequestButton
+                    disabled={!isValid}
+                    css={{ width: '93px' }}
+                    onClick={() => userRepository.checkNickname(getValues('nickname'))}
+                  >
                     중복확인
                   </RequestButton>
                 </Stack>


### PR DESCRIPTION
### 회원가입 프로세스

1. 이메일 입력 후 인증요청한다.
2. 인증코드가 발송되면 코드 Input에 입력 후 코드 검증 => 
    성공 시 이메일인증 button, 코드인증 button, 코드 input 을 전부 disabled
3. 2번에서 말한 input과 button들이
    disabled되지 않거나 step1 유효성검사가 전부 통과되지 않을 시 다음버튼 비활성화
4. step2에서 캐릭터 클릭 후 닉네임 중복확인
5. step3에서 나머지 전부 입력 후 회원가입

부가설명

- 이메일인증요청 시 메일이 오기전까지 시간이 꽤 걸리는데 <br> 버튼에도 로딩처리를 한 다음 메일이 발송 된다음 <br> input에 '인증코드가 발송되었습니다'가 뜨게끔 해놨습니다.

- 마지막에 회원가입 버튼에서 handleSubmit시 step3에 있는 데이터들은 구조분해할당으로 실행이 되는데 <br> step1,2에 있는 input데이터들이 있을 경우 버튼클릭이 아예안먹어서 getValues로 일일이 객체에 담아 함수실행

- 이메일, 코드 인증 시 이메일이 중복이거나 코드가 틀렸을 때의 디자인은 없어서 <br> input에 error넣고 서버에서 오는 error메시지를 helperText로 띄우게끔 했습니다.

// todo
1. 코드 인증버튼 클릭 시  500에러가 떠서 고민 중입니다.
 **( An open transaction is required for pessimistic lock. 로그에는 이렇게 찍힙니다. )**
2. 닉네임 중복확인 API도 간헐적으로 500에러
 **( Query runner already released. Cannot run queries anymore.)**
  닉네임 중복확인 API는 도커 컨테이너 이미지 다 지우고 재실행하면 되었다가 시간지나면 안됩니다..
3. 캐릭터랑 스킬 API연결해야됩니다.
